### PR TITLE
Packer v1.8.1 ovftool v4.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 FROM ubuntu:16.04
 
-ENV PACKER_VERSION=1.1.3
-ENV PACKER_SHA256SUM=b7982986992190ae50ab2feb310cb003a2ec9c5dcba19aa8b1ebb0d120e8686f
+RUN apt-get update && apt-get install -y ca-certificates mkisofs curl unzip jq
 
-ENV OVFTOOL_VERSION 4.1.0-2459827
-ENV OVFTOOL_INSTALLER vmware-ovftool-${OVFTOOL_VERSION}-lin.x86_64.bundle
-# checksum verified at https://my.vmware.com/group/vmware/details?downloadGroup=OVFTOOL410&productId=491
-ENV OVFTOOL_SHA1SUM=b907275c8d744bb54717d24bb8d414b19684fed4
+ENV PACKER_VERSION=1.8.1
+ENV PACKER_SHA256SUM=ae834c85509669c40b26033e5b2210d5594db3921103e38af1e3f537b58338a3
 
-RUN apt-get update && apt-get -y install unzip && apt-get clean
+ENV OVFTOOL_VERSION 4.6.2-22220919
+ENV OVFTOOL_INSTALLER VMware-ovftool-${OVFTOOL_VERSION}-lin.x86_64.bundle
+ENV OVFTOOL_MD5SUM=41048cf17f4d6931b21d61894cf015d6
 
 ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip ./
 RUN echo "${PACKER_SHA256SUM} packer_${PACKER_VERSION}_linux_amd64.zip" | sha256sum -c -
@@ -16,10 +15,13 @@ RUN echo "${PACKER_SHA256SUM} packer_${PACKER_VERSION}_linux_amd64.zip" | sha256
 RUN unzip packer_${PACKER_VERSION}_linux_amd64.zip -d /bin
 RUN rm -f packer_${PACKER_VERSION}_linux_amd64.zip
 
-ADD https://storage.googleapis.com/mortarchive/pub/ovftool/${OVFTOOL_INSTALLER} ./
-RUN echo "${OVFTOOL_SHA1SUM} ${OVFTOOL_INSTALLER}" | sha1sum -c -
-
-RUN sh ${OVFTOOL_INSTALLER} -p /usr/local --console --eulas-agreed --required
-RUN rm ${OVFTOOL_INSTALLER}
+RUN curl "$(curl -XPOST \
+        -d "_SDK_AND_TOOL_DETAILS_INSTANCE_iwlk_fileName=${OVFTOOL_INSTALLER}" \
+        -d '_SDK_AND_TOOL_DETAILS_INSTANCE_iwlk_fileType=Download' \
+        -d '_SDK_AND_TOOL_DETAILS_INSTANCE_iwlk_artifactId=19195' \
+        'https://tap-stg.broadcom.com/web/dp/tools/open-virtualization-format-ovf-tool/latest?p_p_id=SDK_AND_TOOL_DETAILS_INSTANCE_iwlk&p_p_lifecycle=2&p_p_state=normal&p_p_mode=view&p_p_resource_id=downloadArtifact&p_p_cacheability=cacheLevelPage#p_SDK_AND_TOOL_DETAILS_INSTANCE_iwlk;'  | jq -r '.data.downloadUrl')" -o ${OVFTOOL_INSTALLER} && \
+    echo "${OVFTOOL_SHA1SUM} ${OVFTOOL_INSTALLER}" | sha1sum -c - && \
+    sh ${OVFTOOL_INSTALLER} -p /usr/local --console --eulas-agreed --required && \
+    rm ${OVFTOOL_INSTALLER}
 
 ENTRYPOINT ["/bin/packer"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,47 @@
-FROM ubuntu:24.04
+ARG PACKER_VERSION=1.8.1
+ARG PACKER_SHA256SUM=ae834c85509669c40b26033e5b2210d5594db3921103e38af1e3f537b58338a3
 
-RUN apt-get update && apt-get install -y ca-certificates mkisofs curl unzip jq
+ARG OVFTOOL_VERSION=4.6.2-22220919
+ARG OVFTOOL_INSTALLER=VMware-ovftool-${OVFTOOL_VERSION}-lin.x86_64.bundle
+# checksum available at https://tap-stg.broadcom.com/tools/open-virtualization-format-ovf-tool/latest/
+ARG OVFTOOL_MD5SUM=41048cf17f4d6931b21d61894cf015d6
 
-ENV PACKER_VERSION=1.8.1
-ENV PACKER_SHA256SUM=ae834c85509669c40b26033e5b2210d5594db3921103e38af1e3f537b58338a3
+FROM ubuntu:24.04 as dowloader
+ARG PACKER_VERSION
+ARG PACKER_SHA256SUM
+ARG OVFTOOL_VERSION
+ARG OVFTOOL_INSTALLER
+ARG OVFTOOL_MD5SUM
 
-ENV OVFTOOL_VERSION 4.6.2-22220919
-ENV OVFTOOL_INSTALLER VMware-ovftool-${OVFTOOL_VERSION}-lin.x86_64.bundle
-ENV OVFTOOL_MD5SUM=41048cf17f4d6931b21d61894cf015d6
+WORKDIR /download
 
-ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip ./
-RUN echo "${PACKER_SHA256SUM} packer_${PACKER_VERSION}_linux_amd64.zip" | sha256sum -c -
+RUN apt-get update && apt-get install -y curl unzip jq
 
-RUN unzip packer_${PACKER_VERSION}_linux_amd64.zip -d /bin
-RUN rm -f packer_${PACKER_VERSION}_linux_amd64.zip
+RUN curl -O "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip" && \
+    echo "${PACKER_SHA256SUM} packer_${PACKER_VERSION}_linux_amd64.zip" | sha256sum -c - && \
+    mkdir packer && \
+    unzip packer_${PACKER_VERSION}_linux_amd64.zip -d packer
 
 RUN curl "$(curl -XPOST \
-        -d "_SDK_AND_TOOL_DETAILS_INSTANCE_iwlk_fileName=${OVFTOOL_INSTALLER}" \
-        -d '_SDK_AND_TOOL_DETAILS_INSTANCE_iwlk_fileType=Download' \
-        -d '_SDK_AND_TOOL_DETAILS_INSTANCE_iwlk_artifactId=19195' \
-        'https://tap-stg.broadcom.com/web/dp/tools/open-virtualization-format-ovf-tool/latest?p_p_id=SDK_AND_TOOL_DETAILS_INSTANCE_iwlk&p_p_lifecycle=2&p_p_state=normal&p_p_mode=view&p_p_resource_id=downloadArtifact&p_p_cacheability=cacheLevelPage#p_SDK_AND_TOOL_DETAILS_INSTANCE_iwlk;'  | jq -r '.data.downloadUrl')" -o ${OVFTOOL_INSTALLER} && \
-    echo "${OVFTOOL_SHA1SUM} ${OVFTOOL_INSTALLER}" | sha1sum -c - && \
-    sh ${OVFTOOL_INSTALLER} -p /usr/local --console --eulas-agreed --required && \
-    rm ${OVFTOOL_INSTALLER}
+    -d "_SDK_AND_TOOL_DETAILS_INSTANCE_iwlk_fileName=${OVFTOOL_INSTALLER}" \
+    -d '_SDK_AND_TOOL_DETAILS_INSTANCE_iwlk_fileType=Download' \
+    -d '_SDK_AND_TOOL_DETAILS_INSTANCE_iwlk_artifactId=19195' \
+    'https://tap-stg.broadcom.com/web/dp/tools/open-virtualization-format-ovf-tool/latest?p_p_id=SDK_AND_TOOL_DETAILS_INSTANCE_iwlk&p_p_lifecycle=2&p_p_state=normal&p_p_mode=view&p_p_resource_id=downloadArtifact&p_p_cacheability=cacheLevelPage#p_SDK_AND_TOOL_DETAILS_INSTANCE_iwlk;'  | jq -r '.data.downloadUrl')" -o ${OVFTOOL_INSTALLER} && \
+    echo "${OVFTOOL_MD5SUM} ${OVFTOOL_INSTALLER}" | md5sum -c -
+
+
+FROM ubuntu:24.04 as final
+ARG OVFTOOL_INSTALLER
+
+RUN apt-get update && \
+    apt-get install -y ca-certificates mkisofs && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=dowloader /download/packer /bin
+COPY --from=dowloader /download/${OVFTOOL_INSTALLER} /tmp
+
+RUN sh /tmp/${OVFTOOL_INSTALLER} -p /usr/local --console --eulas-agreed --required && \
+    rm /tmp/${OVFTOOL_INSTALLER}
 
 ENTRYPOINT ["/bin/packer"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:24.04
 
 RUN apt-get update && apt-get install -y ca-certificates mkisofs curl unzip jq
 


### PR DESCRIPTION
This PR updates packer to version and ovftool to the latest version. We use a multistage build in order to keep image size small.

Built image is already available as quay.io/buildo/packer-ovftool:v1.8.1-v4.6.2